### PR TITLE
Changed the default ports to avoid conflict with The Onion Router daemon

### DIFF
--- a/torrequest.py
+++ b/torrequest.py
@@ -9,8 +9,8 @@ import time
 
 class TorRequest(object):
   def __init__(self, 
-      proxy_port=9050, 
-      ctrl_port=9051,
+      proxy_port=9150,
+      ctrl_port=9151,
       password=None):
 
     self.proxy_port = proxy_port


### PR DESCRIPTION
I was unable to run TorRequest using the same Tor process, alternatively,
I thought it might be feasible to change the default ports to avoid conflicts.

Were you able to successfully run it with the tor daemon running?

I would like to know your opinion and thanks for continuing the project.